### PR TITLE
Implemented Screen call changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ repositories {
 ```
 3. Add the dependency under ```dependencies```
 ```
-implementation 'com.rudderstack.android.sdk:core:1+'
-implementation 'com.rudderstack.android.integration:appsflyer:1.0.3'
+implementation 'com.rudderstack.android.sdk:core:1.2.1'
+implementation 'com.rudderstack.android.integration:appsflyer:1.0.4'
 
 // appsflyer dependencies
-implementation 'com.appsflyer:af-android-sdk:5.1.1'
+implementation 'com.appsflyer:af-android-sdk:6.4.3'
 implementation 'com.android.installreferrer:installreferrer:1.1.1'  // for attribution
 ```
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ repositories {
 ```
 3. Add the dependency under ```dependencies```
 ```
-implementation 'com.rudderstack.android.sdk:core:1.2.1+'
-implementation 'com.rudderstack.android.integration:appsflyer:1.0.4'
+implementation 'com.rudderstack.android.sdk:core:[1.2.1,)'
+implementation 'com.rudderstack.android.integration:appsflyer:[1.0.4,)'
 
 // appsflyer dependencies
 implementation 'com.appsflyer:af-android-sdk:6.4.3'

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ repositories {
 ```
 3. Add the dependency under ```dependencies```
 ```
-implementation 'com.rudderstack.android.sdk:core:1.2.1'
+implementation 'com.rudderstack.android.sdk:core:1.2.1+'
 implementation 'com.rudderstack.android.integration:appsflyer:1.0.4'
 
 // appsflyer dependencies

--- a/appsflyer/build.gradle
+++ b/appsflyer/build.gradle
@@ -22,7 +22,7 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     // rudder core sdk
-    implementation 'com.rudderstack.android.sdk:core:1.2.1'
+    implementation 'com.rudderstack.android.sdk:core:1.2.1+'
 
     // appsflyer dependencies
     implementation 'com.appsflyer:af-android-sdk:6.4.3'

--- a/appsflyer/build.gradle
+++ b/appsflyer/build.gradle
@@ -8,7 +8,7 @@ android {
         minSdkVersion 14
         targetSdkVersion 30
         versionCode 1
-        versionName "1.0.3"
+        versionName "1.0.4"
     }
 
     buildTypes {
@@ -22,10 +22,10 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     // rudder core sdk
-    compileOnly 'com.rudderstack.android.sdk:core:1.+'
+    implementation 'com.rudderstack.android.sdk:core:1.2.1'
 
     // appsflyer dependencies
-    implementation 'com.appsflyer:af-android-sdk:6.+'
+    implementation 'com.appsflyer:af-android-sdk:6.4.3'
     implementation 'com.android.installreferrer:installreferrer:2.2'
 }
 

--- a/appsflyer/build.gradle
+++ b/appsflyer/build.gradle
@@ -22,7 +22,7 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     // rudder core sdk
-    implementation 'com.rudderstack.android.sdk:core:1.2.1+'
+    implementation 'com.rudderstack.android.sdk:core:[1.2.1,)'
 
     // appsflyer dependencies
     implementation 'com.appsflyer:af-android-sdk:6.4.3'

--- a/appsflyer/build.gradle
+++ b/appsflyer/build.gradle
@@ -5,7 +5,7 @@ android {
     compileSdkVersion 30
 
     defaultConfig {
-        minSdkVersion 14
+        minSdkVersion 19
         targetSdkVersion 30
         versionCode 1
         versionName "1.0.4"

--- a/appsflyer/maven.gradle
+++ b/appsflyer/maven.gradle
@@ -16,7 +16,7 @@ signing {
 
 group = 'com.rudderstack.android.integration'
 archivesBaseName = 'appsflyer'
-version = '1.0.3'
+version = '1.0.4'
 
 File secretPropsFile = project.rootProject.file('local.properties')
 if (secretPropsFile.exists()) {

--- a/appsflyer/src/main/java/com/rudderstack/android/integrations/appsflyer/AppsFlyerIntegrationFactory.java
+++ b/appsflyer/src/main/java/com/rudderstack/android/integrations/appsflyer/AppsFlyerIntegrationFactory.java
@@ -28,6 +28,7 @@ import java.util.Map;
 
 public class AppsFlyerIntegrationFactory extends RudderIntegration<AppsFlyerLib> implements AppsFlyerConversionListener {
     private static final String APPSFLYER_KEY = "AppsFlyer";
+    private Boolean includeScreen = false;
 
     public static RudderIntegration.Factory FACTORY = new Factory() {
         @Override
@@ -44,6 +45,7 @@ public class AppsFlyerIntegrationFactory extends RudderIntegration<AppsFlyerLib>
     private AppsFlyerIntegrationFactory(Object config, RudderConfig rudderConfig) {
         Map<String, Object> destConfig = (Map<String, Object>) config;
         if (destConfig != null && destConfig.containsKey("devKey")) {
+            includeScreen = (Boolean) destConfig.get("includeScreenOrPageName");
             String appsFlyerKey = getString(destConfig.get("devKey"));
             if (!TextUtils.isEmpty(appsFlyerKey)) {
                 AppsFlyerLib.getInstance().init(appsFlyerKey, this, RudderClient.getApplication());
@@ -174,7 +176,14 @@ public class AppsFlyerIntegrationFactory extends RudderIntegration<AppsFlyerLib>
                     }
                     break;
                 case MessageType.SCREEN:
-                    AppsFlyerLib.getInstance().logEvent(RudderClient.getApplication(), "screen", message.getProperties());
+                    String screenName;
+                    if (includeScreen) {
+                        screenName = "Viewed " + message.getEventName() + " Screen";
+                    }
+                    else {
+                        screenName = "screen";
+                    }
+                    AppsFlyerLib.getInstance().logEvent(RudderClient.getApplication(), screenName, message.getProperties());
                     break;
                 case MessageType.IDENTIFY:
                     String userId = message.getUserId();

--- a/appsflyer/src/main/java/com/rudderstack/android/integrations/appsflyer/AppsFlyerIntegrationFactory.java
+++ b/appsflyer/src/main/java/com/rudderstack/android/integrations/appsflyer/AppsFlyerIntegrationFactory.java
@@ -28,7 +28,7 @@ import java.util.Map;
 
 public class AppsFlyerIntegrationFactory extends RudderIntegration<AppsFlyerLib> implements AppsFlyerConversionListener {
     private static final String APPSFLYER_KEY = "AppsFlyer";
-    private Boolean includeScreen = false;
+    private Boolean isNewScreenEnabled = false;
 
     public static RudderIntegration.Factory FACTORY = new Factory() {
         @Override
@@ -45,7 +45,7 @@ public class AppsFlyerIntegrationFactory extends RudderIntegration<AppsFlyerLib>
     private AppsFlyerIntegrationFactory(Object config, RudderConfig rudderConfig) {
         Map<String, Object> destConfig = (Map<String, Object>) config;
         if (destConfig != null && destConfig.containsKey("devKey")) {
-            includeScreen = (Boolean) destConfig.get("includeScreenOrPageName");
+            isNewScreenEnabled = (Boolean) destConfig.get("useRichEventName");
             String appsFlyerKey = getString(destConfig.get("devKey"));
             if (!TextUtils.isEmpty(appsFlyerKey)) {
                 AppsFlyerLib.getInstance().init(appsFlyerKey, this, RudderClient.getApplication());
@@ -177,7 +177,7 @@ public class AppsFlyerIntegrationFactory extends RudderIntegration<AppsFlyerLib>
                     break;
                 case MessageType.SCREEN:
                     String screenName;
-                    if (includeScreen) {
+                    if (isNewScreenEnabled) {
                         screenName = "Viewed " + message.getEventName() + " Screen";
                     }
                     else {

--- a/appsflyer/src/main/java/com/rudderstack/android/integrations/appsflyer/AppsFlyerIntegrationFactory.java
+++ b/appsflyer/src/main/java/com/rudderstack/android/integrations/appsflyer/AppsFlyerIntegrationFactory.java
@@ -44,15 +44,19 @@ public class AppsFlyerIntegrationFactory extends RudderIntegration<AppsFlyerLib>
 
     private AppsFlyerIntegrationFactory(Object config, RudderConfig rudderConfig) {
         Map<String, Object> destConfig = (Map<String, Object>) config;
-        if (destConfig != null && destConfig.containsKey("devKey")) {
-            isNewScreenEnabled = (Boolean) destConfig.get("useRichEventName");
-            String appsFlyerKey = getString(destConfig.get("devKey"));
-            if (!TextUtils.isEmpty(appsFlyerKey)) {
-                AppsFlyerLib.getInstance().init(appsFlyerKey, this, RudderClient.getApplication());
-                AppsFlyerLib.getInstance().setLogLevel(
-                        rudderConfig.getLogLevel() >= RudderLogger.RudderLogLevel.DEBUG ?
-                                AFLogger.LogLevel.VERBOSE : AFLogger.LogLevel.NONE);
-                AppsFlyerLib.getInstance().start(RudderClient.getApplication());
+        if (destConfig != null) {
+            if (destConfig.containsKey("useRichEventName") && destConfig.get("useRichEventName") != null) {
+                isNewScreenEnabled = (Boolean) destConfig.get("useRichEventName");
+            }
+            if (destConfig.containsKey("devKey")) {
+                String appsFlyerKey = getString(destConfig.get("devKey"));
+                if (!TextUtils.isEmpty(appsFlyerKey)) {
+                    AppsFlyerLib.getInstance().init(appsFlyerKey, this, RudderClient.getApplication());
+                    AppsFlyerLib.getInstance().setLogLevel(
+                            rudderConfig.getLogLevel() >= RudderLogger.RudderLogLevel.DEBUG ?
+                                    AFLogger.LogLevel.VERBOSE : AFLogger.LogLevel.NONE);
+                    AppsFlyerLib.getInstance().start(RudderClient.getApplication());
+                }
             }
         }
     }
@@ -177,13 +181,21 @@ public class AppsFlyerIntegrationFactory extends RudderIntegration<AppsFlyerLib>
                     break;
                 case MessageType.SCREEN:
                     String screenName;
+                    Map<String, Object> properties = message.getProperties();
                     if (isNewScreenEnabled) {
-                        screenName = "Viewed " + message.getEventName() + " Screen";
-                    }
-                    else {
+                        if (!TextUtils.isEmpty(message.getEventName())) {
+                            screenName = "Viewed " + message.getEventName() + " Screen";
+                        } else if (properties != null &&
+                                properties.containsKey("name") &&
+                                !TextUtils.isEmpty((String) properties.get("name"))) {
+                            screenName = "Viewed " + properties.get("name") + " Screen";
+                        } else {
+                            screenName = "Viewed Screen";
+                        }
+                    } else {
                         screenName = "screen";
                     }
-                    AppsFlyerLib.getInstance().logEvent(RudderClient.getApplication(), screenName, message.getProperties());
+                    AppsFlyerLib.getInstance().logEvent(RudderClient.getApplication(), screenName, properties);
                     break;
                 case MessageType.IDENTIFY:
                     String userId = message.getUserId();
@@ -226,7 +238,7 @@ public class AppsFlyerIntegrationFactory extends RudderIntegration<AppsFlyerLib>
         if (object instanceof JSONArray) {
             return (JSONArray) object;
         }
-        if(object instanceof List){
+        if (object instanceof List) {
             ArrayList<Object> arrayList = new ArrayList<>();
             arrayList.addAll((Collection<?>) object);
             return new JSONArray(arrayList);
@@ -234,7 +246,7 @@ public class AppsFlyerIntegrationFactory extends RudderIntegration<AppsFlyerLib>
         try {
             return new JSONArray((ArrayList) object);
         } catch (Exception e) {
-            RudderLogger.logDebug("Error while converting the products: "+ object +" to JSONArray type");
+            RudderLogger.logDebug("Error while converting the products: " + object + " to JSONArray type");
         }
         return null;
     }

--- a/sample-kotlin/build.gradle
+++ b/sample-kotlin/build.gradle
@@ -16,7 +16,7 @@ android {
     compileSdkVersion 30
     defaultConfig {
         applicationId "com.rudderstack.test.android"
-        minSdkVersion 16
+        minSdkVersion 19
         targetSdkVersion 30
         versionCode 1
         versionName "1.0"


### PR DESCRIPTION
## Description of the change

- If useRichEventName is enabled at the control plane then screen eventName will be sent in new format.
- Else older format.
- Increased the minSdkVersion of the AppsFlyer sample app to 19, as our Android-SDK min version is 19.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
